### PR TITLE
fix: configure cache get timeout

### DIFF
--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -10,6 +10,7 @@ export default {
     redisConfig: env('REDIS_URL'),
     cacheHeaders: true,
     cacheAuthorizedRequests: false,
+    cacheGetTimeoutInMs: 10000,
   }),
   validator: (config) => {
     if (typeof config.debug !== 'boolean') {
@@ -51,6 +52,10 @@ export default {
     }
     if (typeof config.cacheAuthorizedRequests !== 'boolean') {
       throw new Error(`Invalid config: cacheAuthorizedRequests must be a boolean`);
+    }
+
+    if (typeof config.cacheGetTimeoutInMs !== 'number') {
+      throw new Error(`Invalid config: cacheGetTimeoutInMs must be a number`);
     }
   },
 };

--- a/server/src/services/memory/provider.ts
+++ b/server/src/services/memory/provider.ts
@@ -7,6 +7,7 @@ import { loggy } from '../../utils/log';
 export class InMemoryCacheProvider implements CacheProvider {
   private initialized = false;
   private provider!: LRUCache<string, any>;
+  private cacheGetTimeoutInMs: number;
 
   constructor(private strapi: Core.Strapi) {}
 
@@ -23,12 +24,15 @@ export class InMemoryCacheProvider implements CacheProvider {
     const size = Number(this.strapi.plugin('strapi-cache').config('size'));
     const allowStale = Boolean(this.strapi.plugin('strapi-cache').config('allowStale'));
 
+
     this.provider = new LRUCache({
       max,
       ttl,
       size,
       allowStale,
     });
+
+    this.cacheGetTimeoutInMs = Number(this.strapi.plugin('strapi-cache').config('cacheGetTimeoutInMs'));
 
     loggy.info('Provider initialized');
   }
@@ -45,13 +49,12 @@ export class InMemoryCacheProvider implements CacheProvider {
   async get(key: string): Promise<any | null> {
     if (!this.ready) return null;
 
-    const timeout = 1000;
     return withTimeout(
       () =>
         new Promise((resolve) => {
           resolve(this.provider.get(key));
         }),
-      timeout
+      this.cacheGetTimeoutInMs
     ).catch((error) => {
       loggy.error(`Error during get: ${error?.message || error}`);
       return null;


### PR DESCRIPTION
The default 1000 ms of get timeout is too short in case of heavy loads. In fact, it's often too short to even establish connection from ioredis to redis.

This PR aims to configure the cache get timeout via environment variable.