### PR TITLE
fix: redis ttl unit is second (s) not millisecond (ms)

### DIFF
--- a/playground/config/plugins.ts
+++ b/playground/config/plugins.ts
@@ -20,6 +20,7 @@ export default ({ env }) => ({
 });
 
 // REDIS STANDALONE
+// docker compose -f redis-standalone.docker-compose.yml up
 // export default ({ env }) => ({
 //   'strapi-cache': {
 //     enabled: true,
@@ -41,6 +42,7 @@ export default ({ env }) => ({
 // });
 
 // REDIS CLUSTER
+// docker compose -f redis-cluster.docker-compose.yml up  
 // export default ({ env }) => ({
 //   'strapi-cache': {
 //     enabled: true,
@@ -51,7 +53,7 @@ export default ({ env }) => ({
 //       size: 1024 * 1024 * 1024, // Maximum size of the cache (1 GB) (only for memory cache)
 //       allowStale: false, // Allow stale cache items (only for memory cache)
 //       cacheableRoutes: [], // Caches routes which start with these paths (if empty array, all '/api' routes are cached)
-//       provider: 'memory', // Cache provider ('memory' or 'redis')
+//       provider: 'redis', // Cache provider ('memory' or 'redis')
 //       redisConfig: {
 //         enableAutoPipelining: true,
 //       }, // Redis config takes either a string or an object see https://ioredis.readthedocs.io/en/stable/README for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)

--- a/playground/redis-cluster.docker-compose.yml
+++ b/playground/redis-cluster.docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  cache-cluster-node-0: # port 6379
+    image: docker.io/bitnami/valkey-cluster:8.1
+    volumes:
+      - cache-cluster-node-0:/bitnami/valkey/data
+    environment:
+      ALLOW_EMPTY_PASSWORD: 'yes'
+      VALKEY_CLUSTER_CREATOR: 'yes'
+      VALKEY_CLUSTER_REPLICAS: '0'
+      VALKEY_NODES: 'localhost'
+      VALKEY_CLUSTER_ANNOUNCE_HOSTNAME: "localhost"
+      VALKEY_CLUSTER_PREFERRED_ENDPOINT_TYPE: "hostname"
+    network_mode: host
+
+  redis_insight: # port 5540
+    image: redis/redisinsight
+    volumes:
+      - redisinsight:/data
+    network_mode: host
+
+volumes:
+  redisinsight:
+  cache-cluster-node-0:

--- a/playground/redis-standalone.docker-compose.yml
+++ b/playground/redis-standalone.docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  cache-standalone: # port 6379
+    image: docker.io/bitnami/valkey:8.1
+    environment:
+      ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      - cache-standalone:/bitnami/valkey/data
+    network_mode: host
+
+  redis_insight: # port 5540
+    image: redis/redisinsight
+    volumes:
+      - redisinsight:/data
+    network_mode: host
+
+volumes:
+  redisinsight:
+  cache-standalone:

--- a/server/src/services/redis/provider.ts
+++ b/server/src/services/redis/provider.ts
@@ -66,11 +66,12 @@ export class RedisCacheProvider implements CacheProvider {
     if (!this.ready) return null;
 
     try {
+      // plugin ttl is ms, ioredis ttl is s, so we convert here
       const ttlInMs = Number(this.strapi.plugin('strapi-cache').config('ttl'));
       const ttlInS = Number((ttlInMs/1000).toFixed());
       const serialized = JSON.stringify(val);
       if (ttlInS > 0) {
-        await this.client.set(key, serialized, 'EX', ttlInS); // input ttl is ms, redis ttl is ms
+        await this.client.set(key, serialized, 'EX', ttlInS);
       } else {
         await this.client.set(key, serialized);
       }

--- a/server/src/services/redis/provider.ts
+++ b/server/src/services/redis/provider.ts
@@ -66,10 +66,11 @@ export class RedisCacheProvider implements CacheProvider {
     if (!this.ready) return null;
 
     try {
-      const ttl = Number(this.strapi.plugin('strapi-cache').config('ttl'));
+      const ttlInMs = Number(this.strapi.plugin('strapi-cache').config('ttl'));
+      const ttlInS = Number((ttlInMs/1000).toFixed());
       const serialized = JSON.stringify(val);
-      if (ttl > 0) {
-        await this.client.set(key, serialized, 'EX', ttl);
+      if (ttlInS > 0) {
+        await this.client.set(key, serialized, 'EX', ttlInS); // input ttl is ms, redis ttl is ms
       } else {
         await this.client.set(key, serialized);
       }


### PR DESCRIPTION
I realized that in the examples previously, redis ttl shows more than 1 month in my redis insights dashboard.
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/2d5e9e4e-bd7e-49c1-9e3c-161f87717770" />

Turns out the unit is second, so it means 1000 * 60 * 60 = 3600000 seconds = 41 days.

This is due to the difference in ttl units between providers:
- memory (lru-cache): millisecond (ms)
- redis: second (s)
but we currently input ttl in ms for all providers --> redis caches longer than expected

Solution is to keep the general logic of ttl in ms but divide ttl input by 1000 before passing to redis `set` function.

ioredis generated doc string:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/d7eb5805-5357-4220-bd1d-4b0d58c5242e" />

Changes:
- Update `redis` provider to divide ttl input by 1000 and use `toFixed()` to round up
- Update playground example with redis cluster to `redis` provider
- Add 2 docker compose files to make it easier to test runs with playground examples for redis standalone and cluster