### PR TITLE
fix: correct cache size calculation in config

### DIFF
--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -3,7 +3,7 @@ export default {
     debug: false,
     max: 1000,
     ttl: 1000 * 60 * 60,
-    size: 1024 * 1014 * 10,
+    size: 1024 * 1024 * 10,
     allowStale: false,
     cacheableRoutes: [],
     provider: 'memory',


### PR DESCRIPTION
- Fix typo in default cache size calculation (1014 -> 1024)
- Now properly calculates 10 MB (1024 * 1024 * 10)