### PR TITLE
fix: replace console.error with user notification in PurgeModal

### DIFF
--- a/admin/src/components/PurgeModal/index.tsx
+++ b/admin/src/components/PurgeModal/index.tsx
@@ -31,7 +31,13 @@ function PurgeModal({ buttonText, keyToUse, buttonWidth, contentTypeName }: Purg
         const { data } = await get('/strapi-cache/cacheable-routes');
         return data;
       } catch (error) {
-        console.error('Error fetching cacheable routes:', error);
+        toggleNotification({
+          type: 'warning',
+          message: formatMessage({
+            id: 'strapi-cache.cache.routes.fetch-error',
+            defaultMessage: 'Unable to fetch cacheable routes. Cache purge may not work correctly.',
+          }),
+        });
         return undefined;
       }
     };

--- a/admin/src/translations/de.json
+++ b/admin/src/translations/de.json
@@ -7,5 +7,6 @@
     "strapi-cache.cache.purge.confirmation": "Dies löscht alle Schlüssel, bei denen {key} Teil des Schlüssels ist. Sind Sie sicher, dass Sie den Cache leeren möchten?",
     "strapi-cache.cache.purge.success": "Cache erfolgreich für {key} geleert",
     "strapi-cache.cache.purge.error": "Fehler beim Leeren des Caches für {key}",
-    "strapi-cache.cache.purge.no-content-type": "Kein Inhaltstyp gefunden"
+    "strapi-cache.cache.purge.no-content-type": "Kein Inhaltstyp gefunden",
+    "strapi-cache.cache.routes.fetch-error": "Cacheable-Routen konnten nicht abgerufen werden. Die Cache-Löschung funktioniert möglicherweise nicht korrekt."
 }

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -7,5 +7,6 @@
     "strapi-cache.cache.purge.confirmation": "This purges all keys where {key} is part of the key. Are you sure you want to purge the cache?",
     "strapi-cache.cache.purge.success": "Cache purged successfully for {key}",
     "strapi-cache.cache.purge.error": "Error purging cache for {key}",
-    "strapi-cache.cache.purge.no-content-type": "No content type found"
+    "strapi-cache.cache.purge.no-content-type": "No content type found",
+    "strapi-cache.cache.routes.fetch-error": "Unable to fetch cacheable routes. Cache purge may not work correctly."
 }


### PR DESCRIPTION
## Changes

- Remove `console.error` statement from fetchCacheableRoutes error handler
- Replace with user-friendly notification using notification function
- Add translation keys for error message in English and German
- Improve user experience with proper error feedback