### PR TITLE
docs: fix broken links and improve documentation language

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ In your Strapi project, navigate to `config/plugins.js` and add the following co
     allowStale: false, // Allow stale cache items (only for memory cache)
     cacheableRoutes: ['/api/products', '/api/categories'], // Caches routes which start with these paths (if empty array, all '/api' routes are cached)
     provider: 'memory', // Cache provider ('memory' or 'redis')
-    redisConfig: env('REDIS_URL', 'redis://localhost:6379'), // Redis config takes either a string or an object see https://ioredis.readthedocs.io/en/stable/README for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
-    redisClusterNodes: [], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://ioredis.readthedocs.io/en/stable/README for references
-    redisClusterOptions: {}, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://ioredis.readthedocs.io/en/stable/README for references
+    redisConfig: env('REDIS_URL', 'redis://localhost:6379'), // Redis config takes either a string or an object see https://github.com/redis/ioredis for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
+    redisClusterNodes: [], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://github.com/redis/ioredis for references
+    redisClusterOptions: {}, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://github.com/redis/ioredis for references
     cacheHeaders: true, // Plugin also stores response headers in the cache (set to false if you don't want to cache headers)
     cacheHeadersDenyList: ['access-control-allow-origin', 'content-encoding'], // Headers to exclude from the cache (must be lowercase, if empty array, no headers are excluded, cacheHeaders must be true)
     cacheHeadersAllowList: ['content-type', 'content-security-policy'], // Headers to include in the cache (must be lowercase, if empty array, all headers are cached, cacheHeaders must be true)
     cacheAuthorizedRequests: false, // Cache requests with authorization headers (set to true if you want to cache authorized requests)
-    cacheGetTimeoutInMs: 1000, // Timeout for getting cached data in milliseconds (default is 1 seconds)
+    cacheGetTimeoutInMs: 1000, // Timeout for getting cached data in milliseconds (default is 1 second)
     autoPurgeCache: true, // Automatically purge cache on content CRUD operations
   },
 },
@@ -69,7 +69,7 @@ In your Strapi project, navigate to `config/plugins.js` and add the following co
 The plugin creates three new routes
 
 - `POST /strapi-cache/purge-cache` (purges the whole cache)
-- `POST /strapi-cache/purge-cache/:key` (purges cache entries with have the key in the cache key)
+- `POST /strapi-cache/purge-cache/:key` (purges cache entries that have the key in the cache key)
 - `GET /strapi-cache/cacheable-routes` (returns the cacheable routes defined in the config)
 
 All of these routes are protected by the policies `admin::isAuthenticatedAdmin` and `plugin::strapi-cache.purge-cache`. The `plugin::strapi-cache.purge-cache` policy can be managed in the plugin's permissions section under the settings.
@@ -104,7 +104,7 @@ Access to fetch at 'http://your-backend.com' from origin 'http://your-origin.com
 Request header field cache-control is not allowed by Access-Control-Allow-Headers in preflight response.
 ```
 
-You might need to adjust your CORS middlware settings in Strapi:
+You might need to adjust your CORS middleware settings in Strapi:
 
 ```javascript
 // config/middlewares.{js,ts}

--- a/playground/config/plugins.ts
+++ b/playground/config/plugins.ts
@@ -10,9 +10,9 @@ export default ({ env }) => ({
       allowStale: false, // Allow stale cache items (only for memory cache)
       cacheableRoutes: [], // Caches routes which start with these paths (if empty array, all '/api' routes are cached)
       provider: 'memory', // Cache provider ('memory' or 'redis')
-      redisConfig: env('REDIS_URL', 'redis://localhost:6379'), // Redis config takes either a string or an object see https://ioredis.readthedocs.io/en/stable/README for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
-      redisClusterNodes: [], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://ioredis.readthedocs.io/en/stable/README for references
-      redisClusterOptions: {}, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://ioredis.readthedocs.io/en/stable/README for references
+      redisConfig: env('REDIS_URL', 'redis://localhost:6379'), // Redis config takes either a string or an object see https://github.com/redis/ioredis for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
+      redisClusterNodes: [], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://github.com/redis/ioredis for references
+      redisClusterOptions: {}, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://github.com/redis/ioredis for references
       cacheHeaders: true,
       cacheHeadersDenyList: ['access-control-allow-origin', 'content-encoding'], // Headers to exclude from the cache (must be lowercase, if empty array, no headers are excluded, cacheHeaders must be true)
       cacheHeadersAllowList: ['content-type', 'content-security-policy'], // Headers to include in the cache (must be lowercase, if empty array, all headers are cached, cacheHeaders must be true),
@@ -35,9 +35,9 @@ export default ({ env }) => ({
 //       allowStale: false, // Allow stale cache items (only for memory cache)
 //       cacheableRoutes: [], // Caches routes which start with these paths (if empty array, all '/api' routes are cached)
 //       provider: 'redis', // Cache provider ('memory' or 'redis')
-//       redisConfig: env('REDIS_URL', 'redis://localhost:6379'), // Redis config takes either a string or an object see https://ioredis.readthedocs.io/en/stable/README for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
-//       redisClusterNodes: [], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://ioredis.readthedocs.io/en/stable/README for references
-//       redisClusterOptions: {}, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://ioredis.readthedocs.io/en/stable/README for references
+//       redisConfig: env('REDIS_URL', 'redis://localhost:6379'), // Redis config takes either a string or an object see https://github.com/redis/ioredis for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
+//       redisClusterNodes: [], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://github.com/redis/ioredis for references
+//       redisClusterOptions: {}, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://github.com/redis/ioredis for references
 //       cacheHeaders: true,
 //       cacheHeadersDenyList: ['access-control-allow-origin', 'content-encoding'], // Headers to exclude from the cache (must be lowercase, if empty array, no headers are excluded, cacheHeaders must be true)
 //       cacheHeadersAllowList: ['content-type', 'content-security-policy'], // Headers to include in the cache (must be lowercase, if empty array, all headers are cached, cacheHeaders must be true),
@@ -62,16 +62,16 @@ export default ({ env }) => ({
 //       provider: 'redis', // Cache provider ('memory' or 'redis')
 //       redisConfig: {
 //         enableAutoPipelining: true,
-//       }, // Redis config takes either a string or an object see https://ioredis.readthedocs.io/en/stable/README for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
+//       }, // Redis config takes either a string or an object see https://github.com/redis/ioredis for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
 //       redisClusterNodes: [
 //         {
 //           host: 'localhost',
 //           port: 6379
 //         }
-//       ], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://ioredis.readthedocs.io/en/stable/README for references
+//       ], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://github.com/redis/ioredis for references
 //       redisClusterOptions: {
 //         scaleReads: "all"
-//       }, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://ioredis.readthedocs.io/en/stable/README for references
+//       }, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://github.com/redis/ioredis for references
 //       cacheHeaders: true,
 //       cacheHeadersDenyList: ['access-control-allow-origin', 'content-encoding'], // Headers to exclude from the cache (must be lowercase, if empty array, no headers are excluded, cacheHeaders must be true)
 //       cacheHeadersAllowList: ['content-type', 'content-security-policy'], // Headers to include in the cache (must be lowercase, if empty array, all headers are cached, cacheHeaders must be true),


### PR DESCRIPTION
## Changes

- Replace broken ioredis.readthedocs.io URLs with correct github.com/redis/ioredis
- Fix grammar: 'cache entries with have' -> 'cache entries that have'
- Fix grammar: 'default is 1 seconds' -> 'default is 1 second'
- Fix spelling: 'middlware' -> 'middleware'
- Update 9 instances of broken links across README.md and playground config