### PR TITLE
feat: add namespace support for redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In your Strapi project, navigate to `config/plugins.js` and add the following co
     cacheableRoutes: ['/api/products', '/api/categories'], // Caches routes which start with these paths (if empty array, all '/api' routes are cached)
     provider: 'memory', // Cache provider ('memory' or 'redis')
     redisConfig: env('REDIS_URL', 'redis://localhost:6379'), // Redis config takes either a string or an object see https://github.com/redis/ioredis for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
+    namespace: 'strapi-cache', // Namespace for cache keys (default is 'strapi-cache', only used for Redis cache)
     redisClusterNodes: [], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://github.com/redis/ioredis for references
     redisClusterOptions: {}, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://github.com/redis/ioredis for references
     cacheHeaders: true, // Plugin also stores response headers in the cache (set to false if you don't want to cache headers)
@@ -60,6 +61,7 @@ In your Strapi project, navigate to `config/plugins.js` and add the following co
     cacheAuthorizedRequests: false, // Cache requests with authorization headers (set to true if you want to cache authorized requests)
     cacheGetTimeoutInMs: 1000, // Timeout for getting cached data in milliseconds (default is 1 second)
     autoPurgeCache: true, // Automatically purge cache on content CRUD operations
+    autoPurgeCacheOnStart: true, // Automatically purge cache on Strapi startup
   },
 },
 ```

--- a/admin/src/components/PurgeEntityButton/index.tsx
+++ b/admin/src/components/PurgeEntityButton/index.tsx
@@ -4,8 +4,13 @@ import { useIntl } from 'react-intl';
 
 function PurgeEntityButton() {
   const { formatMessage } = useIntl();
-  const { id, isSingleType, contentType } = useContentManagerContext();
-  const keyToUse = isSingleType ? contentType?.info.singularName : id;
+  const { isSingleType, contentType } = useContentManagerContext();
+  const pluralName =
+    contentType?.kind === 'singleType'
+      ? contentType?.info?.singularName
+      : contentType?.info?.pluralName;
+  const apiPath = `${pluralName}`;
+  const keyToUse = encodeURIComponent(apiPath);
   const contentTypeName = isSingleType
     ? contentType?.info.singularName
     : contentType?.info.pluralName;

--- a/playground/config/plugins.ts
+++ b/playground/config/plugins.ts
@@ -11,6 +11,7 @@ export default ({ env }) => ({
       cacheableRoutes: [], // Caches routes which start with these paths (if empty array, all '/api' routes are cached)
       provider: 'memory', // Cache provider ('memory' or 'redis')
       redisConfig: env('REDIS_URL', 'redis://localhost:6379'), // Redis config takes either a string or an object see https://github.com/redis/ioredis for references to what object is available, the object or string is passed directly to ioredis client (if using Redis)
+      namespace: 'strapi-cache', // Namespace for cache keys (default is 'strapi-cache', only used for Redis cache)
       redisClusterNodes: [], // If provided any cluster node (this list is not empty), initialize ioredis redis cluster client. Each object must have keys 'host' and 'port'. See https://github.com/redis/ioredis for references
       redisClusterOptions: {}, // Options for ioredis redis cluster client. redisOptions key is taken from redisConfig parameter above if not set here. See https://github.com/redis/ioredis for references
       cacheHeaders: true,
@@ -18,6 +19,7 @@ export default ({ env }) => ({
       cacheHeadersAllowList: ['content-type', 'content-security-policy'], // Headers to include in the cache (must be lowercase, if empty array, all headers are cached, cacheHeaders must be true),
       cacheAuthorizedRequests: false,
       autoPurgeCache: true, // Automatically purge cache on content CRUD operations
+      autoPurgeCacheOnStart: true, // Automatically purge cache on Strapi startup
     },
   },
 });

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -9,6 +9,7 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
   try {
     const cacheService = strapi.plugin('strapi-cache').services.service as CacheService;
     const autoPurgeCache = strapi.plugin('strapi-cache').config('autoPurgeCache') as boolean;
+    const autoPurgeCacheOnStart = strapi.plugin('strapi-cache').config('autoPurgeCacheOnStart') as boolean;
     const cacheStore = cacheService.getCacheInstance();
 
     if (!cacheStore) {
@@ -33,6 +34,14 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
           await invalidateGraphqlCache(event, cacheStore, strapi);
         },
       });
+    }
+
+    if (autoPurgeCacheOnStart) {
+      cacheStore.reset().then(() => {
+        loggy.info('Cache purged successfully');
+      }).catch((error) => {
+        loggy.error(`Error purging cache on start: ${error.message}`);
+      })
     }
   } catch (error) {
     loggy.error('Plugin could not be initialized');

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -16,6 +16,7 @@ export default {
     cacheAuthorizedRequests: false,
     cacheGetTimeoutInMs: 1000,
     autoPurgeCache: true,
+    autoPurgeCacheOnStart: true,
   }),
   validator: (config) => {
     if (typeof config.debug !== 'boolean') {
@@ -87,6 +88,12 @@ export default {
     }
     if (typeof config.autoPurgeCache !== 'boolean') {
       throw new Error(`Invalid config: autoPurgeCache must be a boolean`);
+    }
+    if (typeof config.autoPurgeCacheOnStart !== 'boolean') {
+      throw new Error(`Invalid config: autoPurgeCacheOnStart must be a boolean`);
+    }
+    if (config.namespace && typeof config.namespace !== 'string') {
+      throw new Error(`Invalid config: namespace must be a string`);
     }
   },
 };


### PR DESCRIPTION
- add namespace support for redis so that we can use a single redis instance for multiple strapi deploys
- add support for auto cache purge on server startup. defaults to true
- properly manually purge cache by public endpoints instead of entity id