### PR TITLE
fix: fix keyPrefix support for redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ In your Strapi project, navigate to `config/plugins.js` and add the following co
     cacheAuthorizedRequests: false, // Cache requests with authorization headers (set to true if you want to cache authorized requests)
     cacheGetTimeoutInMs: 1000, // Timeout for getting cached data in milliseconds (default is 1 second)
     autoPurgeCache: true, // Automatically purge cache on content CRUD operations
+    autoPurgeCacheOnStart: true, // Automatically purge cache on Strapi startup
   },
 },
 ```

--- a/admin/src/components/PurgeEntityButton/index.tsx
+++ b/admin/src/components/PurgeEntityButton/index.tsx
@@ -4,8 +4,12 @@ import { useIntl } from 'react-intl';
 
 function PurgeEntityButton() {
   const { formatMessage } = useIntl();
-  const { id, isSingleType, contentType } = useContentManagerContext();
-  const keyToUse = isSingleType ? contentType?.info.singularName : id;
+  const { isSingleType, contentType } = useContentManagerContext();
+  const apiPath =
+    contentType?.kind === 'singleType'
+      ? contentType?.info?.singularName
+      : contentType?.info?.pluralName;
+  const keyToUse = encodeURIComponent(apiPath);
   const contentTypeName = isSingleType
     ? contentType?.info.singularName
     : contentType?.info.pluralName;

--- a/playground/config/plugins.ts
+++ b/playground/config/plugins.ts
@@ -18,6 +18,7 @@ export default ({ env }) => ({
       cacheHeadersAllowList: ['content-type', 'content-security-policy'], // Headers to include in the cache (must be lowercase, if empty array, all headers are cached, cacheHeaders must be true),
       cacheAuthorizedRequests: false,
       autoPurgeCache: true, // Automatically purge cache on content CRUD operations
+      autoPurgeCacheOnStart: true, // Automatically purge cache on Strapi startup
     },
   },
 });

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -9,6 +9,7 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
   try {
     const cacheService = strapi.plugin('strapi-cache').services.service as CacheService;
     const autoPurgeCache = strapi.plugin('strapi-cache').config('autoPurgeCache') as boolean;
+    const autoPurgeCacheOnStart = strapi.plugin('strapi-cache').config('autoPurgeCacheOnStart') as boolean;
     const cacheStore = cacheService.getCacheInstance();
 
     if (!cacheStore) {
@@ -33,6 +34,14 @@ const bootstrap = ({ strapi }: { strapi: Core.Strapi }) => {
           await invalidateGraphqlCache(event, cacheStore, strapi);
         },
       });
+    }
+
+    if (autoPurgeCacheOnStart) {
+      cacheStore.reset().then(() => {
+        loggy.info('Cache purged successfully');
+      }).catch((error) => {
+        loggy.error(`Error purging cache on start: ${error.message}`);
+      })
     }
   } catch (error) {
     loggy.error('Plugin could not be initialized');

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -16,6 +16,7 @@ export default {
     cacheAuthorizedRequests: false,
     cacheGetTimeoutInMs: 1000,
     autoPurgeCache: true,
+    autoPurgeCacheOnStart: true,
   }),
   validator: (config) => {
     if (typeof config.debug !== 'boolean') {
@@ -87,6 +88,9 @@ export default {
     }
     if (typeof config.autoPurgeCache !== 'boolean') {
       throw new Error(`Invalid config: autoPurgeCache must be a boolean`);
+    }
+    if (typeof config.autoPurgeCacheOnStart !== 'boolean') {
+      throw new Error(`Invalid config: autoPurgeCacheOnStart must be a boolean`);
     }
   },
 };


### PR DESCRIPTION
- the `del` function expects the relative key without the prefix, as it appends the prefix by itself
- the `keyPrefix` only applies to function that take in a key and not a pattern, so we need to manually handle the `keys` function
- the reset function now flushes only the keys in the configured `keyPrefix`, without flushing the entire Redis instance
- add support for auto cache purge on server startup, defaults to true
- properly manually purge cache by public endpoints