### PR TITLE
feat: enhance cache key generation with authorization support

### DIFF
--- a/server/src/middlewares/cache.ts
+++ b/server/src/middlewares/cache.ts
@@ -20,7 +20,9 @@ const middleware = async (ctx: Context, next: any) => {
     getCacheHeaderConfig();
   const cacheStore = cacheService.getCacheInstance();
   const { url } = ctx.request;
-  const key = generateCacheKey(ctx, keyGenerator);
+  const authorizationHeader = ctx.request.headers['authorization'];
+  const withAuth = authorizationHeader && cacheAuthorizedRequests ? true : false;
+  const key = generateCacheKey(ctx, keyGenerator, withAuth);
   const cacheEntry = await cacheStore.get(key);
   const cacheControlHeader = ctx.request.headers['cache-control'];
   const noCache = cacheControlHeader && cacheControlHeader.includes('no-cache');
@@ -42,8 +44,6 @@ const middleware = async (ctx: Context, next: any) => {
     cacheableRoutes.some((route) => url.startsWith(route)) ||
     (cacheableRoutes.length === 0 && url.startsWith(restApiPrefix));
   const isCacheable = entityIsCacheable ?? routeIsCacheable;
-
-  const authorizationHeader = ctx.request.headers['authorization'];
 
   if (authorizationHeader && !cacheAuthorizedRequests) {
     loggy.info(`Authorized request bypassing cache: ${key}`);

--- a/server/src/middlewares/graphql.ts
+++ b/server/src/middlewares/graphql.ts
@@ -54,10 +54,18 @@ const middleware = async (ctx: any, next: any) => {
 
   const payload = parseGraphqlPayload(body, isGet);
   const rootFields = getRootFieldsFromQuery(payload.query);
-  const graphqlKey = generateGraphqlCacheKey(body, isGet ? 'GET' : 'POST', rootFields, strapi);
+  const authorizationHeader = ctx.request.headers['authorization'];
+  const withAuth = authorizationHeader && cacheAuthorizedRequests ? true : false;
+  const graphqlKey = generateGraphqlCacheKey(
+    body,
+    isGet ? 'GET' : 'POST',
+    rootFields,
+    strapi,
+    withAuth
+  );
   ctx.rootFields = rootFields.length ? rootFields : undefined;
   ctx.operationName = payload.operationName;
-  const key = resolveGraphqlCacheKey(ctx, graphqlKey, keyGenerator);
+  const key = resolveGraphqlCacheKey(ctx, graphqlKey, keyGenerator, withAuth);
   loggy.info(
     `GraphQL request: ${JSON.stringify({
       operationName: payload.operationName,
@@ -76,7 +84,6 @@ const middleware = async (ctx: any, next: any) => {
 
   const cacheControlHeader = ctx.request.headers['cache-control'];
   const noCache = cacheControlHeader && cacheControlHeader.includes('no-cache');
-  const authorizationHeader = ctx.request.headers['authorization'];
 
   if (authorizationHeader && !cacheAuthorizedRequests) {
     loggy.info(`Authorized request bypassing cache: ${key}`);

--- a/server/src/utils/key.ts
+++ b/server/src/utils/key.ts
@@ -20,17 +20,38 @@ export const getCustomCacheKey = (context: Context, keyGenerator?: CacheKeyGener
 export const resolveGraphqlCacheKey = (
   context: Context,
   fallbackKey: string,
-  keyGenerator?: CacheKeyGenerator
-) => getCustomCacheKey(context, keyGenerator) ?? fallbackKey;
-
-export const generateCacheKey = (context: Context, keyGenerator?: CacheKeyGenerator) => {
+  keyGenerator?: CacheKeyGenerator,
+  withAuth: Boolean = false
+) => {
   const customKey = getCustomCacheKey(context, keyGenerator);
   if (customKey !== undefined) {
+    if (withAuth) {
+      return `${customKey}:withAuth`;
+    }
+    return customKey;
+  }
+  return fallbackKey;
+};
+
+export const generateCacheKey = (
+  context: Context,
+  keyGenerator?: CacheKeyGenerator,
+  withAuth: Boolean = false
+) => {
+  const customKey = getCustomCacheKey(context, keyGenerator);
+  if (customKey !== undefined) {
+    if (withAuth) {
+      return `${customKey}:withAuth`;
+    }
     return customKey;
   }
 
   const { url } = context.request;
   const { method } = context.request;
+
+  if (withAuth) {
+    return `${method}:${url}:withAuth`;
+  }
 
   return `${method}:${url}`;
 };
@@ -39,12 +60,13 @@ export const generateGraphqlCacheKey = (
   payload: string,
   method: 'GET' | 'POST' = 'POST',
   rootFields: string[] = [],
-  strapi?: Core.Strapi
+  strapi?: Core.Strapi,
+  withAuth: Boolean = false
 ) => {
   const hash = createHash('sha256').update(payload).digest('base64url');
   const rootFieldsSegment =
     rootFields.length > 0 ? [...rootFields].sort((a, b) => a.localeCompare(b)).join(',') : '_';
-  return `${method}:${strapi?.plugin('graphql')?.config('endpoint', '/graphql') ?? '/graphql'}:${rootFieldsSegment}:${hash}`;
+  return `${method}:${strapi?.plugin('graphql')?.config('endpoint', '/graphql') ?? '/graphql'}:${rootFieldsSegment}:${hash}${withAuth ? ':withAuth' : ''}`;
 };
 
 export const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');


### PR DESCRIPTION
Fix issue #126 by generating a cache key for the authorized requests with a suffix `:withAuth` so if you send a request without an authorization header it gets a new cache key if successful, else it returns a forbidden error so we can separate the authenticated requests from the public requests

### Media
1. Authorized cached request
 <img width="762" height="19" alt="image" src="https://github.com/user-attachments/assets/3fd4d16d-593d-4429-a510-d49e5ee4e794" />

2. Non-authorized cached request
<img width="725" height="19" alt="image" src="https://github.com/user-attachments/assets/77d0b80d-6a58-4269-b748-15653075c685" />


### Notes

> This solution is backward compatible not to affect the other functions or the tests